### PR TITLE
feat: switch to Faraday 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: disable
   SuggestExtensions: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@
 ## 0.5.2
 
 * Use GET `user_info` to check tokens
+
+## 0.6.0
+
+* Switch to Faraday 2 [changelog](https://github.com/lostisland/faraday/blob/main/CHANGELOG.md) to support other updates

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 group :development do
   gem 'rake'
-  gem 'rubocop', '1.20'
+  gem 'rubocop', '1.65'
 end
 
 group :test do

--- a/lib/panda/version.rb
+++ b/lib/panda/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panda
-  VERSION = '0.5.2'
+  VERSION = '0.6.0'
 end

--- a/panda.gemspec
+++ b/panda.gemspec
@@ -7,7 +7,7 @@ require 'panda/version'
 Gem::Specification.new do |s|
   s.name = 'panda-tiktok'
   s.version = Panda::VERSION
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.0.0'
   s.summary = 'Ruby client for TikTok Marketing API'
   s.author = 'Revealbot'
   s.email = 'dev@revealbot.com'
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n").reject { |f| ignored.match(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'faraday', '~> 1.0'
+  s.add_runtime_dependency 'faraday', '~> 2.12.2'
 end


### PR DESCRIPTION
In order to proceed with further updates, we need our dependencies to include Faraday v2 instead of Faraday v1.

This gem does not use middlewares that were previously bundled and now removed. Base class `Faraday::Middleware` is still available. So `ErrorMiddleware` can work as before.

Faraday 2 required Ruby older than 3. Thus, support for 2.7 should be dropped, but we can add 3.4 now. Upcoming `panda` versions won't break Ruby support, I believe, so we could rename current `main` branch to `0.5` and keep it, while using this branch as a new `main`.