### PR TITLE
fix: use POST method for token request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.5.0
 
 * Add `token_info` [method](https://business-api.tiktok.com/portal/docs?id=1765927978092545) to validate TikTok profiles
+
+## 0.5.1
+
+* Use POST method for `token_info` request

--- a/lib/panda.rb
+++ b/lib/panda.rb
@@ -18,14 +18,14 @@ module Panda
       @config ||= Panda::Configuration.new
     end
 
-    def make_get_request(request)
+    def make_request(request)
       connection = Faraday.new do |conn|
         conn.use      Panda::ErrorMiddleware
         conn.request  :json
         conn.response :json
       end
 
-      response = connection.get(request.url, request.params, request.headers)
+      response = connection.run_request(request.method, request.url, request.params, request.headers)
       Panda::HTTPResponse.new(response.status, response.headers, response.body)
     end
   end

--- a/lib/panda/client.rb
+++ b/lib/panda/client.rb
@@ -64,13 +64,13 @@ module Panda
     private
 
     def get_token(path, params = {})
-      request = Panda::HTTPRequest.new('GET', path, params)
-      Panda::TokenInfo.new(Panda.make_get_request(request))
+      request = Panda::HTTPRequest.new('POST', path, params)
+      Panda::TokenInfo.new(Panda.make_request(request))
     end
 
     def get_collection(path, params = {})
       request = Panda::HTTPRequest.new('GET', path, params, 'Access-Token' => access_token)
-      Panda::Collection.new(Panda.make_get_request(request), self)
+      Panda::Collection.new(Panda.make_request(request), self)
     end
   end
 end

--- a/lib/panda/http_request.rb
+++ b/lib/panda/http_request.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'panda/version'
+require 'uri'
 
 module Panda
   class HTTPRequest
@@ -11,10 +12,6 @@ module Panda
       @raw_path = path
       @raw_params = params
       @raw_headers = headers
-    end
-
-    def method
-      raw_method
     end
 
     def url
@@ -39,10 +36,14 @@ module Panda
       )
     end
 
+    def method
+      raw_method.downcase.to_sym
+    end
+
     private
 
     def get?
-      method == 'GET'
+      raw_method == 'GET'
     end
   end
 end

--- a/lib/panda/version.rb
+++ b/lib/panda/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panda
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
<img width="618" alt="Screenshot 2025-01-16 at 17 01 43" src="https://github.com/user-attachments/assets/8ec777dc-a76e-437e-a05a-696bd0ea3752" />

It happened that token info get request uses POST method. This PR fixes method mismatch