### PR TITLE
feat: add Upgraded Smart+ ad groups and ads endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@
 
 * Add `smart_plus_ad_groups` [method](https://business-api.tiktok.com/portal/docs?id=1843314879617026) to list Upgraded Smart+ ad groups
 * Add `smart_plus_ads` [method](https://business-api.tiktok.com/portal/docs/get-upgraded-smart-ads/v1.3) to list Upgraded Smart+ ads
+
+## 0.8.1
+
+* JSON-encode Hash params (e.g. `filtering`) in GET requests so callers no longer have to call `.to_json` themselves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,8 @@
 ## 0.7.0
 
 * Add 'app_list' [method](https://business-api.tiktok.com/portal/docs?id=1740859313270786) to list apps of an advertiser
+
+## 0.8.0
+
+* Add `smart_plus_ad_groups` [method](https://business-api.tiktok.com/portal/docs?id=1843314879617026) to list Upgraded Smart+ ad groups
+* Add `smart_plus_ads` [method](https://business-api.tiktok.com/portal/docs/get-upgraded-smart-ads/v1.3) to list Upgraded Smart+ ads

--- a/README.md
+++ b/README.md
@@ -84,6 +84,36 @@ Get all ads for an advertiser:
 ads = client.ads('advertiser_id')
 ```
 
+### Retrieving Upgraded Smart+ Ad Groups
+
+Fetch all Upgraded Smart+ ad groups for an advertiser. Accepts the same `filtering`, `fields`, `page`, and `page_size` parameters as `ad_groups`:
+```ruby
+smart_plus_ad_groups = client.smart_plus_ad_groups('advertiser_id')
+
+# with filtering
+smart_plus_ad_groups = client.smart_plus_ad_groups(
+  'advertiser_id',
+  filtering: { adgroup_ids: %w[123 456] },
+  page: 1,
+  page_size: 50
+)
+```
+
+### Retrieving Upgraded Smart+ Ads
+
+Fetch all Upgraded Smart+ ads for an advertiser. Accepts the same `filtering`, `fields`, `page`, and `page_size` parameters as `ads`:
+```ruby
+smart_plus_ads = client.smart_plus_ads('advertiser_id')
+
+# with filtering
+smart_plus_ads = client.smart_plus_ads(
+  'advertiser_id',
+  filtering: { ad_ids: %w[123 456] },
+  page: 1,
+  page_size: 50
+)
+```
+
 ### Fetching Reports
 
 Retrieve advertising performance reports with specified dimensions:

--- a/lib/panda/client.rb
+++ b/lib/panda/client.rb
@@ -44,6 +44,16 @@ module Panda
       get_collection('ad/get/', params: params.merge(advertiser_id: advertizer_id))
     end
 
+    # returns a list of Upgraded Smart+ ad groups for an advertiser
+    def smart_plus_ad_groups(advertiser_id, params = {})
+      get_collection('smart_plus/adgroup/get/', params: params.merge(advertiser_id: advertiser_id))
+    end
+
+    # returns a list of Upgraded Smart+ ads for an advertiser
+    def smart_plus_ads(advertiser_id, params = {})
+      get_collection('smart_plus/ad/get/', params: params.merge(advertiser_id: advertiser_id))
+    end
+
     def report(advertiser_id, report_type, dimensions, params = {})
       get_collection(
         'report/integrated/get/',

--- a/lib/panda/http_request.rb
+++ b/lib/panda/http_request.rb
@@ -24,8 +24,8 @@ module Panda
     def params
       return raw_params unless get? && raw_params.is_a?(Hash)
 
-      raw_params.inject({}) do |hash, (key, value)|
-        hash.merge(key => value.is_a?(Array) || value.is_a?(Hash) ? value.to_json : value)
+      raw_params.transform_values do |value|
+        value.is_a?(Array) || value.is_a?(Hash) ? value.to_json : value
       end
     end
 

--- a/lib/panda/http_request.rb
+++ b/lib/panda/http_request.rb
@@ -20,12 +20,12 @@ module Panda
       uri.to_s
     end
 
-    # TikTok accepts arrays in GET request only as json strings
+    # TikTok accepts arrays and nested objects in GET request only as json strings
     def params
       return raw_params unless get? && raw_params.is_a?(Hash)
 
       raw_params.inject({}) do |hash, (key, value)|
-        hash.merge(key => value.is_a?(Array) ? value.to_json : value)
+        hash.merge(key => value.is_a?(Array) || value.is_a?(Hash) ? value.to_json : value)
       end
     end
 

--- a/lib/panda/version.rb
+++ b/lib/panda/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panda
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/lib/panda/version.rb
+++ b/lib/panda/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panda
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end

--- a/spec/cases/client_spec.rb
+++ b/spec/cases/client_spec.rb
@@ -74,4 +74,46 @@ describe Panda::Client do
       subject.app_list(advertiser_id)
     end
   end
+
+  describe '#smart_plus_ad_groups' do
+    let(:advertiser_id) { SecureRandom.hex }
+    let(:filtering) { { adgroup_ids: [SecureRandom.hex] } }
+
+    it 'calls #get_collection with merged params' do
+      expect(subject)
+        .to receive(:get_collection)
+        .with('smart_plus/adgroup/get/', params: { advertiser_id: advertiser_id, filtering: filtering })
+
+      subject.smart_plus_ad_groups(advertiser_id, filtering: filtering)
+    end
+
+    it 'calls #get_collection with only advertiser_id when no extra params' do
+      expect(subject)
+        .to receive(:get_collection)
+        .with('smart_plus/adgroup/get/', params: { advertiser_id: advertiser_id })
+
+      subject.smart_plus_ad_groups(advertiser_id)
+    end
+  end
+
+  describe '#smart_plus_ads' do
+    let(:advertiser_id) { SecureRandom.hex }
+    let(:filtering) { { ad_ids: [SecureRandom.hex] } }
+
+    it 'calls #get_collection with merged params' do
+      expect(subject)
+        .to receive(:get_collection)
+        .with('smart_plus/ad/get/', params: { advertiser_id: advertiser_id, filtering: filtering })
+
+      subject.smart_plus_ads(advertiser_id, filtering: filtering)
+    end
+
+    it 'calls #get_collection with only advertiser_id when no extra params' do
+      expect(subject)
+        .to receive(:get_collection)
+        .with('smart_plus/ad/get/', params: { advertiser_id: advertiser_id })
+
+      subject.smart_plus_ads(advertiser_id)
+    end
+  end
 end

--- a/spec/cases/http_request_spec.rb
+++ b/spec/cases/http_request_spec.rb
@@ -31,6 +31,24 @@ describe Panda::HTTPRequest do
     )
   end
 
+  it 'converts GET hash params to JSON string' do
+    request = described_class.new(
+      'GET',
+      'ad/get/',
+      {
+        advertiser_id: '123',
+        filtering: { ad_status: 'STATUS_ALL', campaign_ids: [1, 2] }
+      }
+    )
+
+    expect(request.params).to eq(
+      {
+        advertiser_id: '123',
+        filtering: '{"ad_status":"STATUS_ALL","campaign_ids":[1,2]}'
+      }
+    )
+  end
+
   it 'adds additional headers' do
     request = described_class.new('GET', 'oauth2/advertiser/get', {}, { 'Access-Token' => 'sometoken' })
 


### PR DESCRIPTION
Adds `smart_plus_ad_groups` and `smart_plus_ads` methods to Panda::Client for the TikTok Upgraded Smart+ APIs. Both accept the same filtering, fields, page, and page_size params as the existing `ad_groups` / `ads` methods. Bumps version to 0.8.1.