### PR TITLE
feat: auto-paginate collection requests (0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@
 ## 0.8.1
 
 * JSON-encode Hash params (e.g. `filtering`) in GET requests so callers no longer have to call `.to_json` themselves
+
+## 0.9.0
+
+* Auto-paginate collection requests: methods like `campaigns`, `ad_groups`, `ads`, etc. now collect every page and return all items, unless a specific `page` is requested

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ Get all campaigns for an advertiser:
 campaigns = client.campaigns('advertiser_id')
 ```
 
+### Pagination
+
+Collection methods (`campaigns`, `ad_groups`, `ads`, `smart_plus_ad_groups`, `smart_plus_ads`, etc.) automatically collect **every page** and return all items in a single collection:
+```ruby
+# fetches page 1, 2, ... up to total_page and returns all items
+all_campaigns = client.campaigns('advertiser_id')
+```
+
+To fetch a single page instead, pass an explicit `page` (use a larger `page_size` to reduce the number of requests when collecting everything):
+```ruby
+# returns only the requested page
+first_page = client.campaigns('advertiser_id', page: 1, page_size: 100)
+```
+
 ### Retrieving Ad Groups
 
 Fetch all ad groups for an advertiser:

--- a/lib/panda/client.rb
+++ b/lib/panda/client.rb
@@ -92,8 +92,27 @@ module Panda
     end
 
     def get_collection(path, params: {}, collection_key: 'list')
+      collection = request_collection(path, params, collection_key)
+
+      # honor an explicitly requested page and return it as-is
+      return collection if params.key?(:page) || params.key?('page')
+
+      append_remaining_pages(collection, path, params, collection_key)
+    end
+
+    def request_collection(path, params, collection_key)
       request = Panda::HTTPRequest.new('GET', path, params, 'Access-Token' => access_token)
       Panda::Collection.new(Panda.make_request(request), self, collection_key)
+    end
+
+    # recursively fetches pages 2..total_page and appends their items to the first collection
+    def append_remaining_pages(collection, path, params, collection_key, page = 2)
+      return collection if collection.total_page.nil? || page > collection.total_page
+
+      next_page = request_collection(path, params.merge(page: page), collection_key)
+      collection.concat(next_page)
+
+      append_remaining_pages(collection, path, params, collection_key, page + 1)
     end
   end
 end

--- a/lib/panda/version.rb
+++ b/lib/panda/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panda
-  VERSION = '0.8.1'
+  VERSION = '0.9.0'
 end

--- a/spec/cases/client_spec.rb
+++ b/spec/cases/client_spec.rb
@@ -116,4 +116,77 @@ describe Panda::Client do
       subject.smart_plus_ads(advertiser_id)
     end
   end
+
+  describe '#get_collection (pagination)' do
+    let(:path) { 'campaign/get/' }
+
+    def page_body(page, items)
+      {
+        'code' => 0,
+        'message' => 'OK',
+        'data' => {
+          'list' => items,
+          'page_info' => { 'page' => page, 'page_size' => 2, 'total_number' => 5, 'total_page' => 3 }
+        }
+      }
+    end
+
+    context 'when no page is specified' do
+      before do
+        responses = {
+          1 => Panda::HTTPResponse.new(200, {}, page_body(1, [{ 'id' => '1' }, { 'id' => '2' }])),
+          2 => Panda::HTTPResponse.new(200, {}, page_body(2, [{ 'id' => '3' }, { 'id' => '4' }])),
+          3 => Panda::HTTPResponse.new(200, {}, page_body(3, [{ 'id' => '5' }]))
+        }
+
+        allow(Panda).to receive(:make_request) { |request| responses.fetch(request.raw_params.fetch(:page, 1)) }
+      end
+
+      it 'collects items from every page' do
+        collection = subject.send(:get_collection, path)
+
+        expect(collection.map { |item| item['id'] }).to eq(%w[1 2 3 4 5])
+      end
+
+      it 'requests each page exactly once' do
+        subject.send(:get_collection, path)
+
+        expect(Panda).to have_received(:make_request).exactly(3).times
+      end
+    end
+
+    context 'when a specific page is specified' do
+      before do
+        allow(Panda)
+          .to receive(:make_request)
+          .and_return(Panda::HTTPResponse.new(200, {}, page_body(2, [{ 'id' => '3' }, { 'id' => '4' }])))
+      end
+
+      it 'returns only the requested page' do
+        collection = subject.send(:get_collection, path, params: { page: 2 })
+
+        expect(collection.map { |item| item['id'] }).to eq(%w[3 4])
+      end
+
+      it 'makes a single request' do
+        subject.send(:get_collection, path, params: { page: 2 })
+
+        expect(Panda).to have_received(:make_request).once
+      end
+    end
+
+    context 'when the response has no page info' do
+      before do
+        body = { 'code' => 0, 'message' => 'OK', 'data' => [{ 'id' => '1' }] }
+        allow(Panda).to receive(:make_request).and_return(Panda::HTTPResponse.new(200, {}, body))
+      end
+
+      it 'returns the single collection without extra requests' do
+        collection = subject.send(:get_collection, path)
+
+        expect(collection.map { |item| item['id'] }).to eq(%w[1])
+        expect(Panda).to have_received(:make_request).once
+      end
+    end
+  end
 end


### PR DESCRIPTION
Collection methods now collect every page and return all items in a single collection, unless a specific page is requested. Splits get_collection into request_collection and append_remaining_pages, which walks pages 2..total_page using total_page from the first response.